### PR TITLE
Add Back Demo and Conferences Pages

### DIFF
--- a/welcome-guide/pass-demonstrations-conferences.md
+++ b/welcome-guide/pass-demonstrations-conferences.md
@@ -1,2 +1,55 @@
 # PASS Demonstrations at Conferences
 
+### Eclipse Pass Project Briefing, January 2024
+
+In 2023, the PASS team at Johns Hopkins University achieved significant milestones including a series of monthly releases that introduced a new back-end architecture, enhanced API, and a range of system improvements to support a more efficient and user-friendly experience. Alongside development, the team engaged in community building with academic partners and hosting providers to explore piloting opportunities and integration needs for 2024. The PASS project plans to focus on expanding user engagement, building a broader community of institutions interested in utilizing PASS, enhancing system administration tools, and making application improvements, including better integration with funder repositories.
+
+For more details visit the [Project Briefing](https://drive.google.com/file/d/1WvAUQLLXbGAsCjBDgjUK-so0glmjwsaF/view)
+
+***
+
+### CNI Presentation, December 2023
+
+{% embed url="https://youtu.be/PjllYf86sMQ?si=XVQBWllfWva526HT" %}
+PASS CNI Presentation December 2023
+{% endembed %}
+
+For more details about this presentation visit the [CNI website](https://www.cni.org/topics/ci/the-nsf-public-access-initiative-projects-funded-and-catalytic-aims-of-the-program)
+
+***
+
+### Eclipse PASS Project Briefing, January 2023
+
+In 2022, the Public Access Submission System (PASS) project embarked on significant advancements, notably transitioning to an Eclipse Foundation open-source project, and upgrading its server architecture. This strategic move to the Eclipse Foundation enhanced PASS with engineering, community management, and organizational governance expertise, enabling more effective collaboration with agencies and institutions. Furthermore, the architectural upgrade enhanced the system's API, simplified deployment, and streamlined system management, setting the stage for broader community engagement and institutional collaboration.
+
+For more details visit the [Project Briefing](https://drive.google.com/file/d/12jCpURDYDbfiAnzjBMeukL1zSBsf-hB8/view)
+
+***
+
+### CNI Presentation, December 2022
+
+{% embed url="https://youtu.be/KuoZEb7Zbn0?si=XJBcQ9WgOT7mjEkA" %}
+PASS CNI Presentation December 2022
+{% endembed %}
+
+View the [Presentation Slides](https://www.cni.org/wp-content/uploads/2022/12/Eclipse-PASS-CNI-Presentation-2022-12-13-Bill-Branan.pdf), or more details about this presentation visit the [CNI Website](https://www.cni.org/topics/ci/how-the-public-access-submission-system-is-ideally-suited-to-address-the-new-ostp-memorandum)
+
+***
+
+### CNI Presentation, Spring 2020
+
+{% embed url="https://vimeo.com/417845449" %}
+PASS CNI Presentation Spring 2020
+{% endembed %}
+
+For more details about this presentation visit the [CNI Website](https://www.cni.org/topics/repositories/packaging-specification-for-simultaneous-deposit-of-articles-and-data-into-multiple-repositories)
+
+***
+
+### FORCE11 Presentation, November 2018
+
+{% embed url="https://youtu.be/dI8n66fvlXQ?si=jZWu8VViEz1Xe9w-" %}
+PASS FORCE11 Presentation November 2018
+{% endembed %}
+
+View the [Presentation Slides](https://zenodo.org/records/1453344), or for more details about the presentation visit the [FORCE11 Website](https://force11.org/force2018/)


### PR DESCRIPTION
This was inadvertently taken out by a gitbook merge. Adding back this page. Also this will test some auto generated gitbook syntax for video embedding to see how it works via a GitHub merge vs. GitBook merge.