### PR TITLE
Update deposit services docs for Swordv2 removal

### DIFF
--- a/developer-documentation/deposit-service/README.md
+++ b/developer-documentation/deposit-service/README.md
@@ -19,7 +19,6 @@ A package can be thought of as a zip file containing user submitted files plus m
 specifications govern the structure of the zip file and the kind of metadata provided:
 
 * BagIT
-* DSpace METS
 * NIHMS bulk submission spec
 
 In the context of documenting inputs and outputs, DS uses the public PASS model as input and output, and produces a

--- a/developer-documentation/deposit-service/ds-assemblers.md
+++ b/developer-documentation/deposit-service/ds-assemblers.md
@@ -52,7 +52,7 @@ The primary benefit of extending `AbstractAssembler` is that the logic for ident
 submission and creating their representation as `List<DepositSubmission>` is shared. Subclasses of `AbstractAssembler`
 must instantiate and return a `PackageStream`.
 
-Examples can be found at: `DspaceMetsAssembler`, `NihmsAssembler`, `InvenioRdmAssembler`, and `BagItAssembler`
+Examples can be found at: `DspaceAssembler`, `NihmsAssembler`, `InvenioRdmAssembler`, and `BagItAssembler`
 
 ### PackageStream API
 
@@ -109,7 +109,6 @@ _When developing your own `Assembler` that returns a `ArchivingPackageStream`, y
 
 Examples of implemented package providers:
 
-* `DspaceMetsPackageProvider`
 * `NihmsPackageProvider`
 * `BagItPackageProvider`
 
@@ -129,9 +128,7 @@ multiple threads, therefore all the code paths executed by an `Assembler` must b
 
 `AbstractAssembler` and `ArchivingPackageStream` are already thread-safe; your concrete implementation
 of `AbstractAssembler` and `PackageProvider` will need to maintain that thread safety. Streaming a package inherently
-involves maintaining state, including the updating of metadata for resources as they are streamed. Package Providers
-will often maintain state as they generate supplemental resources for a package; the `J10PMetadataDomWriter`
-, for example, builds a METS.xml file using a DOM.
+involves maintaining state, including the updating of metadata for resources as they are streamed.
 
 One strategy for maintaining thread safety is to scope any state maintained over the course of streaming a package to
 the executing thread. `Assembler` implementations are free to use whatever mechanisms they wish to ensure thread
@@ -143,7 +140,6 @@ kept on the Thread stack and not in the JVM heap). For example:
 * `AbstractAssembler` implementations instantiate a new `ArchivingPackageStream` each time.
 * `DefaultStreamWriterImpl` instantiates a new `ResourceBuilder` for each resource being streamed using a factory
   pattern.
-* The `DspaceMetsAssembler` uses a factory pattern to instantiate its state-maintaining objects.
 
 The factory objects may be kept in shared memory (i.e. as instance member variables), but the objects produced by the
 factories are maintained in the Thread stack (as method variables). After a `PackageStream` has been opened and
@@ -189,7 +185,6 @@ well written and test all aspects of a generated package.
 Examples of these ITs:
 
 * `BagItThreadedAssemblyIT`
-* `J10PMetsThreadedAssemblyIT`
 * `NihmsThreadedAssemblyIT`
 
 ### PackageVerifier
@@ -219,7 +214,6 @@ a `DepositFile` from the submission and maps it to its expected location in the 
 
 Examples: 
 
-* `DspaceMetsPackageVerifier`
 * `NihmsPackageVerifier`
 
 ## Runtime

--- a/developer-documentation/deposit-service/ds-business.md
+++ b/developer-documentation/deposit-service/ds-business.md
@@ -24,14 +24,12 @@ status of the `Deposit` resource associated with the `Submission` will be update
 ## Failure Handling
 
 A _failed_ `Deposit` or `Submission` is marked with `Deposit.DepositStatus = FAILED` or `Submission.AggregateDepositStatus = FAILED`.
-When a resource has been marked `FAILED`, Deposit Services will ignore any messages relating to the resource. Failed `Deposit`
-resources will be retried as part of the `DepositStatusUpdaterJob` job. Once all `Deposit` resource are successful, the
-failed `Submission.AggregateDepositStatus` will be updated.
+When a resource has been marked `FAILED`, Deposit Services will ignore any messages relating to the resource.
 
 A resource will be considered as failed when errors occur during the processing of `Submission` and `Deposit` resources.
 Some errors may be caused by transient network issues, or a server being rebooted. In the case of such failures,
-Deposit Services will retry for n number of days after the `Submission` is created. The number of days
-is set in an application property named `pass.status.update.window.days`.
+The `Deposit.depositStatus` will be set to `RETRY`, and Deposit Services will retry for n number of days after the 
+`Submission` is created. The number of days is set in an application property named `pass.status.update.window.days`.
 
 `Submission` resources are failed when:
 

--- a/developer-documentation/deposit-service/ds-configuration.md
+++ b/developer-documentation/deposit-service/ds-configuration.md
@@ -73,53 +73,17 @@ A possible repository configuration is replicated below:
 ```json
 {
   "JScholarship": {
-    "deposit-config": {
-      "processing": {
-        "beanName": "org.eclipse.pass.deposit.messaging.status.DefaultDepositStatusProcessor"
-      },
-      "mapping": {
-        "http://dspace.org/state/archived": "accepted",
-        "http://dspace.org/state/withdrawn": "rejected",
-        "default-mapping": "submitted"
-      }
-    },
     "assembler": {
-      "specification": "http://purl.org/net/sword/package/METSDSpaceSIP"
+      "specification": "DSpace",
+      "beanName": "DSpaceAssembler"
     },
     "transport-config": {
-      "auth-realms": [
-        {
-          "mech": "basic",
-          "username": "fakeuser",
-          "password": "fakepass",
-          "url": "https://jscholarship.library.jhu.edu/"
-        }
-      ],
       "protocol-binding": {
-        "protocol": "SWORDv2",
-        "username": "${dspace.user}",
-        "password": "${dspace.password}",
-        "server-fqdn": null,
-        "server-port": null,
-        "service-doc": "https://${dspace.server}/server/swordv2/servicedocument",
-        "default-collection": "https://${dspace.server}/server/swordv2/collection/123456789/2",
-        "on-behalf-of": null,
-        "deposit-receipt": true,
-        "user-agent": "pass-deposit/x.y.z"
+        "protocol": "DSpace"
       }
     }
   },
   "PubMed Central": {
-    "deposit-config": {
-      "processing": {
-      },
-      "mapping": {
-        "INFO": "accepted",
-        "ERROR": "rejected",
-        "WARN": "rejected",
-        "default-mapping": "submitted"
-      }
-    },
     "assembler": {
       "specification": "nihms-native-2017-07"
     },
@@ -137,12 +101,6 @@ A possible repository configuration is replicated below:
 }
 ```
 ### Customizing Repository Configuration Elements
-
-The repository configuration above will not be suitable for production. A production deployment needs to provide
-updated authentication credentials and ensure the correct value for the default SWORD collection URL
-- `default-collection`. Each `transport-config` section should be reviewed for correctness, paying special attention
-  to `protocol-binding` and `auth-realm` blocks: update `username` and `password` elements, and ensure correct values
-  for URLs.
 
 Values may be parameterized by any property or environment variable.
 

--- a/developer-documentation/deposit-service/ds-model.md
+++ b/developer-documentation/deposit-service/ds-model.md
@@ -61,7 +61,7 @@ Builder.
 
 ### Configuration Model
 
-* `Packager`: encapsulates configuration of the `Assembler`, `Transport`, and `DepositStatusProcessor` for every
+* `Packager`: encapsulates configuration of the `Assembler` and `Transport` for every
   downstream repository in `repositories.json`. Each repository configured in `repositories.json` should to reference
   a `Repository` resource in the PASS repository.
 * `RepositoryConfig`: Java representation of a single repository configuration in `repositories.json`. The
@@ -91,8 +91,6 @@ Builder.
 
 ### Messaging Model
 
-* `DepositStatusProcessor`: responsible for updating the `Deposit.depositStatus` property of a `Deposit` resource,
-  typically by resolving the URL in the `Deposit.depositStatusRef` property and parsing its content.
 * `CriticalRepositoryInteraction`: CRI for short. Performs an optimistic locking (`If-Match` using an Etag) "critical"
   modification on a PASS resource, with a built-in retry mechanism when a modification fails. Each CRI has a
   pre-condition, critical section, and post-condition. The pre-condition must be met before the critical section is
@@ -188,19 +186,20 @@ a `Transport` implementation.
 
 The `Assembler` and the `PackageProvider` create the package, and the `Transport` is the "how" of how a package is
 transferred to a downstream repository. Choosing the `Transport` to be used depends on the support of the downstream
-repository for things like SFTP, SWORD, InvenioRDM (HTTP) or other protocols.
+repository for things like SFTP, DSpace API (HTTP), InvenioRDM (HTTP) or other protocols.
 
 For example, a BagIt `Assembler` and `PackageProvider` would produce BagIt packages. Those packages may be transported
-to downstream repositories using SFTP, SWORDv2, or a custom Transport implementation. The `Transport` to be used is a
+to downstream repositories using SFTP or a custom Transport implementation. The `Transport` to be used is a
 matter of configuration in `repositories.json`.
 
 ### SFTP
 
 Supports the transport of the package stream using SFTP.
 
-#### SWORDv2
+#### DSPACE API
 
-Supports the transport of the package stream using the [SWORD protocol version 2](http://swordapp.github.io/SWORDv2-Profile/SWORDProfile.html).
+Supports the transport of the package stream that will be sent to a DSpace repository. This implementation uses
+HTTP to call the DSpace REST API.
 
 #### InvenioRDM
 

--- a/developer-documentation/deposit-service/ds-status.md
+++ b/developer-documentation/deposit-service/ds-status.md
@@ -42,8 +42,9 @@ Deposit status is enumerated in the `DepositStatus` class. Deposit services cons
    , i.e. custody of the `Submission` has successfully been transferred to the downstream `Repository`.
 * `REJECTED` (_terminal_): the custodial content of the `Submission` has been rejected by the `Deposit`'s `Repository`,
   i.e. the downstream `Repository` has refused to accept custody of the `Submission` content.
-* `FAILED` (_intermediate_): the transfer of custodial content to the `Repository` failed, or there was some other error
+* `FAILED` (_terminal_): the transfer of custodial content to the `Repository` failed, or there was some other error
   updating the status of the `Deposit`.
+* `RETRY` (_intermediate_): the downstream repository was not reachable. The Deposit will be retried at a later time.
 
 ## RepositoryCopy Status
 


### PR DESCRIPTION
Updates deposit services documentation to reflect changes made in https://github.com/eclipse-pass/pass-support/pull/157.

The main change is the removal of the Swordv2 transport, `DspaceMetsPackageProvider` , and `DepositStatusProcessor`.