### PR TITLE
Update release documentation

### DIFF
--- a/developer-documentation/release/README.md
+++ b/developer-documentation/release/README.md
@@ -1,213 +1,52 @@
 # PASS Release
 
-This release section outlines the overall process and steps to perform the community release of PASS. It provides in-depth details of each step and the procedures to perform the release manually. There are workflows available that [automate the release process](release-steps-with-automations.md), enabling the release of all projects at once or individually.
+This section outlines the overall process and steps to perform the community release of PASS.
 
-## Summary
+A PASS release produces a set of Java artifacts, Docker images, and Documentation. Java artifacts are published on Sonatype Central Portal and Maven Central repositories. Docker images are pushed to [GitHub Container Registry (GHCR)](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry). Source code is tagged and release notes made available.
 
-A PASS release produces a set of Java artifacts, and Docker images. Java artifacts are pushed to Sonatype Nexus and Maven Central repositories. Docker images are pushed to [GitHub Container Registry (GHCR)](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry). The PASS Docker environment is updated with references to the released images. Source code is tagged and release notes made available.
+Each release of PASS has its own version which is used by every component. PASS uses `MAJOR.MINOR.PATCH` [semantic versioning](https://semver.org/) approach. The version should be chosen based on those guidelines.
 
-Each release of PASS has its own version which is used by every component. PASS uses `MAJOR.MINOR.PATCH` [semantic versioning](https://semver.org/) approach.
-The version should be chosen based on those guidelines.
-
-## Community Preparation
+## Release Steps
 
 * Assign a Release Manager, the person who will be responsible for the release process. The Release Manager must be a [PASS committer](https://www.eclipse.org/projects/handbook/#roles-cm).
-* Ensure all code commits and PRs intended for the release have been merged.
-* Issue a code freeze statement on the [Eclipse PASS slack #pass-dev channel](https://eclipse-pass.slack.com/archives/C035MNLRD44) to notify all developers that a release is imminent and the release manager will not consider any further changes.
-
-## Process
-
 * Choose a release version that communicates the magnitude of the change.
-* Create a release checklist issue from the [main repository create new issue page](https://github.com/eclipse-pass/main/issues/new/choose).
-* Perform the release.
-* Test the release.
-* Publish release notes.
-* Post a message about the release to the [PASS Google Group](https://groups.google.com/g/pass-general).
-  * Release manager will draft the message, allowing the [technical lead](https://github.com/markpatton) and [community manager](https://github.com/kineticsquid) to provide feedback before posting.
-  * Message should include at least: an overview of the high level changes in the release, plans for the next release, and a link to the changelog for the release.
+* Create a GitHub issue in the main repository using the `Release Checklist Issue` template from the [main repository create new issue page](https://github.com/eclipse-pass/main/issues/new/choose).
+* Follow the steps in the Release GitHub issue to complete the release.
+  * See [these instructions](#triggering-the-release-all-github-workflow) for running the `Publish: Release All` GitHub Action workflow.
 
-## Manual Release Requirements
+### Triggering the Release All GitHub workflow
 
-Most of the PASS release process is automated, but if we need to do parts of the process manually, make sure the following software is installed:
+* **Before running the `Publish: Release All` workflow, the [GitHub PAT configuration](#github-personal-access-token-setup) is required.**
+* Navigate to [Publish: Release All](https://github.com/eclipse-pass/main/actions/workflows/pass-complete-release.yml)
+* Click on the `Run workflow` dropdown button
+* Confirm the branch is `main` and enter the versions in the `Release version` and `Next dev version` fields
+    * Release version: full release version, e.g. 1.10.0. These versions should be regarded as immutable. These releases for Java projects cannot be updated or deleted.
+    * Next dev version: snapshot or development versions, e.g. 1.11.0-SNAPSHOT (please use all capital letters for the SNAPSHOT suffix). These development versions are intended to be overwritten.
+* Click the `Run workflow` button
+* After a few seconds, a new workflow run should appear in the table with a yellow (in-progress) status dot. Clicking on that will allow you to monitor the run's progress by watching logs.
 
-| Name           | Version |
-|----------------|---------|
-| Java           | 17      |
-| Maven          | 3.8.x   |
-| Docker         | 20.10.x |
-| Docker Compose | 2.x     | 
+It is recommended that you monitor the automation after triggering it to make sure it completes successfully.
 
-### Sonatype
+<figure><img src="../../.gitbook/assets/main-release-page.png" alt="Running Release All Workflow"><figcaption><p>Running Release All Workflow</p></figcaption></figure>
 
-The Sonatype deployment is handled by the automations. This information is provided for doing a Java release manually.
+### GitHub Personal Access Token Setup
 
-Developers will need a Sonatype account to release Java projects.
-Maven must be configured to use the account by modifying your `~/.m2/settings.xml`. To learn more about Sonatype, documentation is available on their [website](https://central.sonatype.org/publish/publish-guide/).
+The `Publish: Release All` GitHub workflows depend on the `JAVA_RELEASE_PAT` secret having permission to access all the eclipse-pass repositories and write packages.
+You have to create a new classic Personal Access Token (PAT) to do the release (GitHub/Settings/Developer Settings/Personal access tokens/Tokens (classic)).
+If you do so, set the expiration to 7 days, check the `repo` and the `write:packages` scope (subscopes under `repo`
+and `write:packages` will be selected too).
 
-Example pom setup:
-```xml
-<settings>
-  <servers>
-    <server>
-      <id>ossrh</id>
-      <username>YOUR_SONATYPE_USERNAME</username
-      <password>YOUR_SONATYPE_PASSWORD</password>
-    </server>
-  </servers>
-  <profiles>
-    <profile>
-      <id>ossrh</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <gpg.executable>gpg</gpg.executable>
-        <gpg.passphrase>YOUR_GPG_PASSPHRASE</gpg.passphrase>
-      </properties>
-    </profile>
-  </profiles>
-</settings>
-
+How to set the secret in the main repository using the gh command line tool [GitHub CLI](https://cli.github.com/):
 ```
-### GitHub Container Registry (GHCR)
-
-Developers will need a GitHub account which is a member of the [eclipse-pass](https://github.com/eclipse-pass) organization. 
-
-## Release Sequence
-
-**The [Publish: Release All](https://github.com/eclipse-pass/main/actions/workflows/pass-complete-release.yml) GitHub workflow will release all projects in the correct order.**  
-
-If a manual release is required, a specific order must be followed. The Java projects must follow a strict sequence, following its dependency hierarchy. Other Javascript based projects can be released in any order. Both the Java and non-Java releases can be done in parallel, as there are no direct code dependencies between them.
-
-1. [`main`](https://github.com/eclipse-pass/main)
-2. Java projects
-   1. [`pass-core`](https://github.com/eclipse-pass/pass-core)
-   2. [`pass-support`](https://github.com/eclipse-pass/pass-support)
-3. Non-Java projects
-   * [`pass-ui`](https://github.com/eclipse-pass/pass-ui)
-   * [`pass-acceptance-testing`](https://github.com/eclipse-pass/pass-acceptance-testing)
-4. [`pass-docker`](https://github.com/eclipse-pass/pass-docker)
-
-These projects have GitHub workflow automations in place to perform releases that need to be triggered manually. See more detailed [release steps with automations](release-steps-with-automations.md).
-
-## Java Release
-
-The release automations will follow these steps. **You will only need to follow this process if the automations fail.**
-
-Maven is used to perform many of the release tasks:
-
-* Sets versions and builds 
-* Tests
-* Pushes release artifacts 
-* May also build Docker images
-
-The versions of all the Java artifacts are the same for a release. The parent pom in `main` sets the version to be inherited by all its children; therefore this project needs to be released first, as all other projects need to reference it. After this project is released, other projects are released in an order which guarantees that all PASS dependencies for them have already been released. You will need to wait for artifacts to show up in Maven Central before building a module which depends on them.
-
-For convenience, we set and export environment variables RELEASE for the release version, and NEXT for the next development version; e.g., `export RELEASE=0.1.0` and `export NEXT=0.2.0-SNAPSHOT`.
-For each of these child projects, we first clone the source from GitHub, and operating on the principal branch (usually `main`).
-
-Update the reference to the parent pom and set the release version.
-```
-mvn versions:update-parent -DparentVersion=$RELEASE
-mvn versions:set -DnewVersion=$RELEASE
+gh auth login
+gh secret set JAVA_RELEASE_PAT --body <PAT_VALUE> --repo eclipse-pass/main
 ```
 
-After this, we do build and push the artifacts to Sonatype, commit the version change, and tag it:
-```
-mvn -ntp -P release clean deploy
-git commit -am "Update version to $RELEASE"
-git tag $RELEASE
-```
+## Alternate Release Procedures
 
-Push any created images to GHCR after logging in. Visit the GitHub docs [Working with the Container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more information.
-```
-docker push IMAGE_NAME:$RELEASE
-```
+The [Publish: Release All](https://github.com/eclipse-pass/main/actions/workflows/pass-complete-release.yml) GitHub Action workflow is the preferred way to complete the PASS release. 
+However, it is possible to execute a PASS release with project automations one at a time or manually if needed. This is not recommended unless absolutely necessary since executing the
+release manually introduces the chance of making mistakes.
 
-Push commits and tags to GitHub:
-```
-git push origin
-git push origin --tags
-```
-
-Finally, the new development code needs to be built and pushed to GitHub. Repeat the process above with the dev version, but do not create the tag.
-
-At this point, we should have deployed the release to Sonatype (and eventually to Maven Central), pushed a tag to GitHub, and deployed the new development release to Sonatype.
-
-In addition, the project may be released on GitHub. This provides a way to add release notes for a particular project. A GitHub release is done manually by uploading artifacts through the UI. The release version and tag should be the same used for Maven Central. Release notes can be automatically generated from commit messages and then customized.
-
-See the GitHub [Java Release Workflow](https://github.com/eclipse-pass/main/blob/main/.github/workflows/release.yml) for the details on the exact commands that are run.
-
-### Manual Release Steps for Main, Pass-Core, Pass-Support
-
-* Update POM to release version
-* Commit release version update
-* Tag release version
-* Build and deploy to Sonatype
-* Push any generated Docker images to GHCR
-* Update POM to dev version
-* Commit dev version update
-* Build and deploy to Sonatype
-* Wait for artifacts in Maven Central
-* Push any generated Docker images to GHCR
-* Push commits to GitHub
-
-
-## JavaScript Projects
-
-The following projects can be released by performing the following steps when the release needs to be performed manually.
-
-### PASS-UI
-
-Update the version in `package.json` and in `build.sh`, and commit those changes via a PR to the `pass-ui` repo.
-
-Build a new docker image from within the `pass-ui` repo by running:
-```
-sh build.sh ~/pass-docker/.env
-```
-Note, you might want to ensure `node_modules` are removed first to ensure a clean build.
-
-Push that image to GHCR. For example: `docker push ghcr.io/eclipse-pass/pass-ui:<your-version-tag-here>`
-
-### PASS-Auth
-
-Update the version in `package.json`, and commit that change via a PR to the `pass-auth` repo.
-
-Build a new docker image from within the `pass-auth`, for example by running:
-```
-docker build --no-cache -t ghcr.io/eclipse-pass/pass-auth:<your-version-tag>
-```
-Push that image to GHCR. For example: `docker push ghcr.io/eclipse-pass/pass-auth:<your-version-tag-here>`
-
-### PASS-Acceptance Testing
-
-All that's required is to tag a new release in the GitHub UI.
-
-After pushing the images to GHCR, update the appropriate image lines in `docker-compose.yml` and `pass-docker` with the new sha returned by the pushes to GHCR. Open a pull request against `pass-docker` with these updates.
-
-Once acceptance-tests successfully run in CI in your `pass-docker` PR, and once you've done some additional manual spot checking while running `pass-docker` locally, go ahead and tag a new release in the Github UI for each of the following projects: `pass-ui`, `pass-ui-public`, `pass-auth` and `pass-acceptance-testing`. 
-
-## Image Customization
-
-Here's what you need to change manually before building a new image version in order to bring in code changes. If the docker compose service is not mentioned here, you do not need to make any manual changes. All images must be built manually using docker compose, following the [docker compose rebuilding / updating](#docker compose-rebuilding--updating) steps except `pass-core` which is built by Maven.
-
-### Building `pass-ui` Image
-In `.env`, by default, `EMBER_GIT_BRANCH` should have a value of `main`. If you need to point to a specific branch update the value of `EMBER_GIT_BRANCH`. You can use the name of a tag or a specific commit hash.
-
-## Testing
-
-Manual testing can be done using the newly updated pass-docker to run the release locally. Acceptance testing is run automatically on GitHub against pass-docker/main.
-
-## Post Release
-
-  * Update release notes
-  * Update project documentation
-  * Deploying the release
-
-### Update Release Notes
-
-1. Ensure that there is a milestone for the release.
-2. Get a list of all issues that are closed and in the `eclipse-pass` project by going to the [main repository issue list](https://github.com/eclipse-pass/main/issues?page=1&q=is%3Aissue+is%3Aclosed+project%3Aeclipse-pass%2F4).
-3. Check that the correct tickets are in the release milestone.
-4. Archive the release tickets in the Project by going to the [Kanban Board](https://github.com/orgs/eclipse-pass/projects/4/views/2), scrolling to the Done column, verifying that all tickets in the list have the new version tag, then selecting the ellipsis button and "Archive all cards".
-5. Include in the Release Notes a link to the issues resolved by the release, for example [this milestone](https://github.com/eclipse-pass/main/milestone/11?closed=1).
+* [Release Projects One At a Time](release-steps-project-one-at-a-time.md)
+* [Manual Release](release-steps-manual.md)

--- a/developer-documentation/release/release-steps-manual.md
+++ b/developer-documentation/release/release-steps-manual.md
@@ -1,0 +1,172 @@
+# Manual Release
+
+This section provides the details on performing a release one project at a time manually by the release manager.
+
+**[Publish: Release All](https://github.com/eclipse-pass/main/actions/workflows/pass-complete-release.yml) GitHub Action workflow is the preferred way to release PASS. Releasing PASS manually should only be done if absolutely required.**
+
+## Required Software
+
+The following software is required:
+
+| Name           | Version |
+|----------------|---------|
+| Java           | 17      |
+| Maven          | 3.8.x   |
+| Docker         | 20.10.x |
+| Docker Compose | 2.x     |
+| Git            |         |
+
+### Sonatype
+
+Developers will need a Sonatype Central Portal account to release Java projects.
+Maven must be configured to use the account by modifying your `~/.m2/settings.xml`. To learn more about Sonatype, documentation is available on their [website](https://central.sonatype.org/publish/publish-portal-guide/).
+
+Example pom setup:
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>central</id>
+      <username>YOUR_SONATYPE_USERNAME</username>
+      <password>YOUR_SONATYPE_PASSWORD</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>central</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.executable>gpg</gpg.executable>
+        <gpg.passphrase>YOUR_GPG_PASSPHRASE</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
+</settings>
+
+```
+### GitHub Container Registry (GHCR)
+
+Developers will need a GitHub account which is a member of the [eclipse-pass](https://github.com/eclipse-pass) organization.
+
+## Release Sequence
+
+If a manual release is required, a specific order must be followed. The Java projects must follow a strict sequence, following its dependency hierarchy. Other Javascript based projects can be released in any order. Both the Java and non-Java releases can be done in parallel, as there are no direct code dependencies between them.
+
+1. [`main`](https://github.com/eclipse-pass/main)
+2. Java projects
+    1. [`pass-core`](https://github.com/eclipse-pass/pass-core)
+    2. [`pass-support`](https://github.com/eclipse-pass/pass-support)
+3. Non-Java projects
+    * [`pass-ui`](https://github.com/eclipse-pass/pass-ui)
+    * [`pass-acceptance-testing`](https://github.com/eclipse-pass/pass-acceptance-testing)
+4. [`pass-docker`](https://github.com/eclipse-pass/pass-docker)
+
+## Java Release
+
+Maven is used to perform many of the release tasks:
+
+* Sets versions and builds
+* Tests
+* Pushes release artifacts
+* May also build Docker images
+
+The versions of all the Java artifacts are the same for a release. The parent pom in `main` sets the version to be inherited by all its children; therefore this project needs to be released first, as all other projects need to reference it. After this project is released, other projects are released in an order which guarantees that all PASS dependencies for them have already been released. You will need to wait for artifacts to show up in Maven Central before building a module which depends on them.
+
+For convenience, we set and export environment variables RELEASE for the release version, and NEXT for the next development version; e.g., `export RELEASE=0.1.0` and `export NEXT=0.2.0-SNAPSHOT`.
+For each of these child projects, we first clone the source from GitHub, and operating on the principal branch (usually `main`).
+
+Update the reference to the parent pom and set the release version.
+```
+mvn versions:update-parent -DparentVersion=$RELEASE
+mvn versions:set -DnewVersion=$RELEASE
+```
+
+After this, we do build and push the artifacts to Sonatype, commit the version change, and tag it:
+```
+mvn -ntp -P release clean deploy
+git commit -am "Update version to $RELEASE"
+git tag $RELEASE
+```
+
+Push any created images to GHCR after logging in. Visit the GitHub docs [Working with the Container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more information.
+```
+docker push IMAGE_NAME:$RELEASE
+```
+
+Push commits and tags to GitHub:
+```
+git push origin
+git push origin --tags
+```
+
+Finally, the new development code needs to be built and pushed to GitHub. Repeat the process above with the dev version, but do not create the tag.
+
+At this point, we should have deployed the release to Sonatype (and eventually to Maven Central), pushed a tag to GitHub, and deployed the new development release to Sonatype.
+
+In addition, the project may be released on GitHub. This provides a way to add release notes for a particular project. A GitHub release is done manually by uploading artifacts through the UI. The release version and tag should be the same used for Maven Central. Release notes can be automatically generated from commit messages and then customized.
+
+See the GitHub [Java Release Workflow](https://github.com/eclipse-pass/main/blob/main/.github/workflows/release.yml) for the details on the exact commands that are run.
+
+### Manual Release Steps for Main, Pass-Core, Pass-Support
+
+* Update POM to release version
+* Commit release version update
+* Tag release version
+* Build and deploy to Sonatype
+* Push any generated Docker images to GHCR
+* Update POM to dev version
+* Commit dev version update
+* Build and deploy to Sonatype
+* Wait for artifacts in Maven Central
+* Push any generated Docker images to GHCR
+* Push commits to GitHub
+
+## JavaScript Projects
+
+The following projects can be released by performing the following steps when the release needs to be performed manually.
+
+### PASS-UI
+
+Update the version in `package.json` and in `build.sh`, and commit those changes via a PR to the `pass-ui` repo.
+
+Build a new docker image from within the `pass-ui` repo by running:
+```
+sh build.sh ~/pass-docker/.env
+```
+Note, you might want to ensure `node_modules` are removed first to ensure a clean build.
+
+Push that image to GHCR. For example: `docker push ghcr.io/eclipse-pass/pass-ui:<your-version-tag-here>`
+
+### PASS-Acceptance Testing
+
+All that's required is to tag a new release in the GitHub UI.
+
+After pushing the images to GHCR, update the appropriate image lines in `docker-compose.yml` and `pass-docker` with the new sha returned by the pushes to GHCR. Open a pull request against `pass-docker` with these updates.
+
+Once acceptance-tests successfully run in CI in your `pass-docker` PR, and once you've done some additional manual spot checking while running `pass-docker` locally, go ahead and tag a new release in the GitHub UI for each of the following projects: `pass-ui` and `pass-acceptance-testing`.
+
+## Image Customization
+
+Here's what you need to change manually before building a new image version in order to bring in code changes. If the docker compose service is not mentioned here, you do not need to make any manual changes. All images must be built manually using docker compose, following the [docker compose rebuilding / updating](#docker compose-rebuilding--updating) steps except `pass-core` which is built by Maven.
+
+### Building `pass-ui` Image
+In `.env`, by default, `EMBER_GIT_BRANCH` should have a value of `main`. If you need to point to a specific branch update the value of `EMBER_GIT_BRANCH`. You can use the name of a tag or a specific commit hash.
+
+## Testing
+
+Manual testing can be done using the newly updated pass-docker to run the release locally. Acceptance testing is run automatically on GitHub against pass-docker/main.
+
+## Post Release
+
+* Update release notes
+* Update project documentation
+
+### Update Release Notes
+
+1. Ensure that there is a milestone for the release.
+2. Get a list of all issues that are closed and in the `eclipse-pass` project by going to the [main repository issue list](https://github.com/eclipse-pass/main/issues?page=1&q=is%3Aissue+is%3Aclosed+project%3Aeclipse-pass%2F4).
+3. Check that the correct tickets are in the release milestone.
+4. Archive the release tickets in the Project by going to the [Kanban Board](https://github.com/orgs/eclipse-pass/projects/4/views/2), scrolling to the Done column, verifying that all tickets in the list have the new version tag, then selecting the ellipsis button and "Archive all cards".
+5. Include in the Release Notes a link to the issues resolved by the release, for example [this milestone](https://github.com/eclipse-pass/main/milestone/11?closed=1).

--- a/developer-documentation/release/release-steps-project-one-at-a-time.md
+++ b/developer-documentation/release/release-steps-project-one-at-a-time.md
@@ -1,21 +1,12 @@
-# Project release sequence
+# Release Projects One At a Time
 
-This article provides the details on performing a release by the release manager.
+This section provides the details of performing a release one project at a time with automations by the release manager.
 
-## Release All Projects
-
-The [Publish: Release All](https://github.com/eclipse-pass/main/actions/workflows/pass-complete-release.yml) is a GitHub workflow that will release all the PASS projects in the correct order, build and push docker images, and create GitHub Releases.
-The `Publish: Release All` requires [GitHub PAT configuration](#github-personal-access-token-setup).
-
-The `Publish: Release All` workflow is the preferred method of doing a PASS release. If for some reason, a PASS release needs to be done one project at a time, follow the steps in [Release Projects One At a Time](#release-projects-one-at-a-time) section.
-
-## Release Projects One At a Time
+**[Publish: Release All](https://github.com/eclipse-pass/main/actions/workflows/pass-complete-release.yml) GitHub Action workflow is the preferred way to release PASS. Releasing PASS one project at a time should only be done if absolutely required.**
 
 ### Java projects
-The [Publish: release all Java modules](https://github.com/eclipse-pass/main/actions/workflows/pass-java-release.yml) combines all the Java projects together and then releases them in one single workflow.
-The `Publish: release all Java modules` requires GitHub PAT configuration.  See [GitHub Personal Access Token Setup](#github-personal-access-token-setup).
 
-If needed, the individual Java components can be released individually. Release these in the order defined here due to 
+The individual Java projects can be released individually. Release these in the order defined here due to 
 dependencies. Between each of these releases, you will need to wait for the Java artifacts to appear on Maven Central. 
 This will give you enough time to do other release activities, such as releasing non-Java artifacts. The release 
 workflows should wait for you, but checking will mitigate any potential issues with the release.
@@ -25,7 +16,7 @@ workflows should wait for you, but checking will mitigate any potential issues w
    * [Maven central](https://central.sonatype.com/artifact/org.eclipse.pass/eclipse-pass-parent)
 2. [pass-core](https://github.com/eclipse-pass/pass-core)
    * [Release workflow](https://github.com/eclipse-pass/pass-core/actions/workflows/release.yml)
-   * [Maven Central](https://central.sonatype.com/artifact/org.eclipse.pass/pass-core-main/0.4.0)
+   * [Maven Central](https://central.sonatype.com/artifact/org.eclipse.pass/pass-core-main)
    * [Package](https://github.com/eclipse-pass/pass-core/pkgs/container/pass-core-main)
 3. [pass-support](https://github.com/eclipse-pass/pass-support)
    * [Release workflow](https://github.com/eclipse-pass/pass-support/actions/workflows/release.yml)
@@ -36,10 +27,9 @@ workflows should wait for you, but checking will mitigate any potential issues w
    * [Journal Loader](https://github.com/orgs/eclipse-pass/packages/container/package/pass-journal-loader)
    * [NIHMS Loader](https://github.com/orgs/eclipse-pass/packages/container/package/pass-nihms-loader)
 
-
 ### Non-Java projects
 
-These can be released in any order. You should release these between releasing Java components, while waiting for artifacts to become available in Maven Central.
+These can be released in any order. You should release these between releasing Java projects, while waiting for artifacts to become available in Maven Central.
 
 * [pass-ui](https://github.com/eclipse-pass/pass-ui)
   * [Release workflow](https://github.com/eclipse-pass/pass-ui/actions/workflows/release.yml)
@@ -53,9 +43,6 @@ This must be released last because it relies on some of the Docker images that w
 
 1. [pass-docker](https://github.com/eclipse-pass/pass-docker)
    * [Release workflow](https://github.com/eclipse-pass/pass-docker/actions/workflows/release.yml)
-   * Packages:
-      * [idp](https://github.com/orgs/eclipse-pass/packages/container/package/idp)
-      * [demo-ldap](https://github.com/orgs/eclipse-pass/packages/container/package/demo-ldap)
 
 ### GitHub code release
 
@@ -73,26 +60,11 @@ You will have to manually create a GitHub release through the GitHub web interfa
 
 Take [eclipse-pass/main](https://github.com/eclipse-pass/main) as an example.
 
-* Navigate to the `Actions` tab in your target repository. Select the workflow you want to trigger, e.g. the Release workflow in [Publish: Release All](https://github.com/eclipse-pass/main/actions/workflows/pass-complete-release.yml)
+* Navigate to the `Actions` tab in your target repository. Select the workflow you want to trigger, e.g. the Release workflow in [Publish: manual full release](https://github.com/eclipse-pass/main/actions/workflows/release.yml)
 * Click on the `Run workflow` button
 * Input the branch you wish to run the release against and the desired `Release` and `Next dev` versions
   * Release version: full release version, e.g. 1.10.0. These versions should be regarded as immutable. These releases for Java projects cannot be updated or deleted.
-  * Next development version: snapshot or development versions, e.g. 1.11.0-SNAPSHOT (please use all capital letters for the SNAPSHOT suffix). These development versions are intended to be overwritten.
+  * Next dev version: snapshot or development versions, e.g. 1.11.0-SNAPSHOT (please use all capital letters for the SNAPSHOT suffix). These development versions are intended to be overwritten.
 * After a few seconds, a new workflow run should appear in the table with a yellow (in-progress) status dot. Clicking on that will allow you to monitor the run's progress by watching logs.
 
-It is recommended that you monitor the automation after triggering it to make sure it completes successfully before moving on to release the next component.
-
-<figure><img src="../../.gitbook/assets/main-release-page.png" alt="Running Release All Workflow"><figcaption><p>Running Release All Workflow</p></figcaption></figure>
-
-## GitHub Personal Access Token Setup
-
-Some GitHub workflows depend on the `JAVA_RELEASE_PAT` secret having permission to access all the eclipse-pass repositories and write packages.
-You have to create a new classic Personal Access Token (PAT) to do the release (GitHub/Settings/Developer Settings/Personal access tokens/Tokens (classic)).
-If you do so, set the expiration to 7 days, check the `repo` and the `write:packages` scope (subscopes under `repo`
-and `write:packages` will be selected too).
-
-How to set the secret in the main repository using the gh command line tool [GitHub CLI](https://cli.github.com/):
-```
-gh auth login
-gh secret set JAVA_RELEASE_PAT --body <PAT_VALUE> --repo eclipse-pass/main
-```
+It is recommended that you monitor the automation after triggering it to make sure it completes successfully before moving on to release the next project.


### PR DESCRIPTION
So that the main release documentation is for releasing using the Release All workflow.  Links are available for releasing a project at a time and manual and described as alternative only when absolutely necessary.