### PR TITLE
Add wf to retarget PR branch if needed

### DIFF
--- a/.bookignore
+++ b/.bookignore
@@ -1,0 +1,3 @@
+
+# Ignore github workflows
+.github/

--- a/.github/workflows/retarget-pr-branch.yml
+++ b/.github/workflows/retarget-pr-branch.yml
@@ -1,0 +1,23 @@
+name: "Retarget PR to development branch"
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  retarget:
+    runs-on: ubuntu-latest
+    # Only run if the PR is targeting 'main'
+    if: github.event.pull_request.base.ref == 'main'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Change Base Branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit $PR_NUMBER --base development


### PR DESCRIPTION
This will ensure the target branch on a PR is the `development` branch.